### PR TITLE
Update Namespace for AndroidX Support

### DIFF
--- a/src/android/QRScanner.java
+++ b/src/android/QRScanner.java
@@ -24,7 +24,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import android.hardware.Camera;
 import android.provider.Settings;
-import android.support.v4.app.ActivityCompat;
+import androidx.core.app.ActivityCompat;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
 


### PR DESCRIPTION
Hello,

with the latest Cordova Android release (version 10.1.2) can unfortunately not use this plugin. 

The problem is that a new namespace is used (see screen).

![image](https://user-images.githubusercontent.com/25218984/166878910-b32e6bc6-5651-48f5-9931-89e058fea315.png)

Is it possible to integrate the changes from this fork to enable a working plugin again? ( +NPM Update)
 
I hope you can help :-)